### PR TITLE
chore: approve pnpm workspace builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
     "oxlint": "^1.73.0",
     "typescript": "^7.0.2",
     "unocss": "^66.7.5"
-  }
+  },
+  "packageManager": "pnpm@11.13.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  "@parcel/watcher": true
+  esbuild: true


### PR DESCRIPTION
pnpm v10+ has a security feature called [approve-builds](https://pnpm.io/cli/approve-builds) to explicitly approve which dependencies can run scripts during installations.

When `pnpm install` detects dependencies with build scripts, it blocks them by default and outputs a message instructing to run `pnpm approve-builds` to explicitly allow which packages can execute their installation scripts.

---

To make next project installations and contributions to be a bit more convenient - let's approve the existing dependencies. 😎 

Additionally specify package manager & its version in the `package.json` to ensure everyone are using the same version.